### PR TITLE
feat: 카카오 지도 API와 연동 후 KakaoMap.jsx 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+	<script type="text/javascript" 
+		src="//dapi.kakao.com/v2/maps/sdk.js?appkey=08b77cf50b86f13486c61ef0888560a7">
+	</script>
+	<title>Vite + React</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^5.3.0",
+        "react-kakao-maps-sdk": "^1.1.27",
         "react-router-dom": "^6.26.2",
         "sass": "^1.79.3",
         "swiper": "^11.1.14"
@@ -5466,6 +5467,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/kakao.maps.d.ts": {
+      "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.40.tgz",
+      "integrity": "sha512-nX69MB1ok04epe3OqS+/tEeWBbU31GSQbvDPJmQRRltzzqn6t4jBsO5v1nzalUjCKzwcH2CptOc767NZ7Hbu3g==",
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5999,6 +6006,20 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-kakao-maps-sdk": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/react-kakao-maps-sdk/-/react-kakao-maps-sdk-1.1.27.tgz",
+      "integrity": "sha512-1EwYkYsjTDRFqysKStDasFMrFTXcLx2AyRlqMoWD7ONWhRqpjx9M874hkhEEHrnypP2eSIhhDLe0EiSKp3bd2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.22.15",
+        "kakao.maps.d.ts": "^0.1.39"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18",
+        "react-dom": "^16.8 || ^17 || ^18"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",
@@ -10954,6 +10975,11 @@
         "object.values": "^1.1.6"
       }
     },
+    "kakao.maps.d.ts": {
+      "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.40.tgz",
+      "integrity": "sha512-nX69MB1ok04epe3OqS+/tEeWBbU31GSQbvDPJmQRRltzzqn6t4jBsO5v1nzalUjCKzwcH2CptOc767NZ7Hbu3g=="
+    },
     "keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -11321,6 +11347,15 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-kakao-maps-sdk": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/react-kakao-maps-sdk/-/react-kakao-maps-sdk-1.1.27.tgz",
+      "integrity": "sha512-1EwYkYsjTDRFqysKStDasFMrFTXcLx2AyRlqMoWD7ONWhRqpjx9M874hkhEEHrnypP2eSIhhDLe0EiSKp3bd2Q==",
+      "requires": {
+        "@babel/runtime": "^7.22.15",
+        "kakao.maps.d.ts": "^0.1.39"
+      }
     },
     "react-refresh": {
       "version": "0.14.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.3.0",
+    "react-kakao-maps-sdk": "^1.1.27",
     "react-router-dom": "^6.26.2",
     "sass": "^1.79.3",
     "swiper": "^11.1.14"

--- a/src/components/Layout/AppLayout.jsx
+++ b/src/components/Layout/AppLayout.jsx
@@ -6,6 +6,7 @@ import Home from '@/pages/Home';
 import ClothingSearch from '@/pages/ClothingSearch';
 import PartySearch from '@/pages/PartySearch';
 import MyClothes from '@/pages/MyClothes';
+import KakaoMap from '../../utils/KakaoMap';
 
 function AppLayout() {
   return (

--- a/src/utils/KakaoMap.jsx
+++ b/src/utils/KakaoMap.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Map, MapMarker } from "react-kakao-maps-sdk";
+
+function KakaoMap({ info, setInfo }) {
+	const positions = [
+		{
+			title: "카이스트 정문",
+			latlng: { lat: 36.365679109284, lng: 127.36395917051 },
+		},
+		{
+			title: "창의학습관",
+			latlng: { lat: 36.370379109284, lng: 127.36265917051 },
+		},
+		{
+			title: "KI 빌딩",
+			latlng: { lat: 36.367979109284, lng: 127.36395917051 },
+		},
+	]
+	return (
+		<Map
+			center={{ lat: 36.370379109284, lng: 127.36265917051 }}
+			style={{ width: '600px', height: '600px' }}
+			level={4}
+		>
+			{positions.map((position, index) => (
+				<MapMarker
+					key={`${position.title}-${position.latlng}`}
+					position={position.latlng} // 마커를 표시할 위치
+					image={{
+						src: "https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png", // 마커이미지의 주소입니다
+						size: {
+							width: 24,
+							height: 35
+						}, // 마커이미지의 크기입니다
+					}}
+					title={position.title} // 마커의 타이틀, 마커에 마우스를 올리면 타이틀이 표시됩니다
+					onClick={(marker) => {
+						setInfo({ name: marker.Gb })
+					}}
+				/>
+			))}
+		</Map>
+	)
+}
+
+export default KakaoMap;


### PR DESCRIPTION
- 제목 : branch 이름

## 🔘Part

- [ ] FE

<br/>

## 🔎 작업 내용

- 카카오 지도 API 기능을 추가하였습니다.
- Applayout.jsx에 <KakaoMap>을 추가하여 메인 페이지에 지도가 정상적으로 표시되는 것을 확인했습니다.

  <br/>

## 이미지 첨부

![image](https://github.com/user-attachments/assets/60ba5457-b9ad-4d62-9914-bbe126b4f307)

<br/>

## 🔧 앞으로의 과제

- 메인 앱의 지도가 필요한 기능에 적용해야 합니다.

  <br/>

## ➕ 이슈 링크

- https://www.notion.so/Home-Components-de996020a36744d481bc8f8cbe7424a1?pvs=4

<br/>
